### PR TITLE
Setup ESPHome components directory

### DIFF
--- a/esphome/components/README.md
+++ b/esphome/components/README.md
@@ -1,0 +1,15 @@
+# ESPHome Components
+
+## Living Room Light
+
+__File__: living_room_light.yaml
+__Description__ This component controls the living room light using a monochromatic light platform.
+__Usage__: Copy the living_room_light.yaml file to your ESPHome configuration directory and customize the __wifi__ settings.
+
+## Custom Components
+
+### My Custom Component
+
+__File__: custom_components/my_custom_component.h
+__Description__: This is a custom ESPHome component for advanced functionality.
+__Usage__: Include this header in your ESPHome configuration and implement the custom logic.

--- a/esphome/components/custom_components/my_custom_component.h
+++ b/esphome/components/custom_components/my_custom_component.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "esphome.h"
+
+class MyCustomComponent : public Component {
+  public:
+    void setup() override {
+      // Custom setup code here
+    }
+    void loop() override {
+      // Custom loop code here
+    }
+};

--- a/esphome/components/living_room_light.yaml
+++ b/esphome/components/living_room_light.yaml
@@ -1,0 +1,18 @@
+esphome:
+  name: living_room_light
+
+wifi:
+  ssid: "your_ssid"
+  password: "your_password"
+
+logger:
+
+_pi:
+  platform: gpio
+  pin : 16
+  id: output_component
+
+light:
+  - platform: monochromatic
+    name: "Living Room Light"
+    output: output_component


### PR DESCRIPTION
This PR sets up a directory structure for ESPHome components in the `esphome/components` directory. It includes:

- A sample ESPHome configuration for the living room light (`living_room_light.yaml`).
- A custom component (`my_custom_component.h`).
- A README file to document the components.

### New Files:
- `esphome/components/living_room_light.yaml`
- `esphome/components/custom_components/my_custom_component.h`
- `esphome/components/README.md`